### PR TITLE
config::enviroments nixpkgs-channels -> nixpkgs

### DIFF
--- a/config/enviroments/cad_and_graphics.nix
+++ b/config/enviroments/cad_and_graphics.nix
@@ -5,7 +5,7 @@ let
   baseconfig = { allowUnfree = true; };
   unstableTarball =
     fetchTarball
-      https://github.com/NixOS/nixpkgs-channels/archive/nixos-unstable.tar.gz;
+      https://github.com/NixOS/nixpkgs/archive/nixos-unstable.tar.gz;
   unstable = import unstableTarball
   {
     config = baseconfig;


### PR DESCRIPTION
The nixpkgs-channels repository is deprecated and no longer gets updates. As a consequence, your configuration here is stuck in January 2021.